### PR TITLE
Add automated cleanup to ONT instrument transfer script

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,9 @@
 # TACA Version Log
 
+## 20241118.1
+
+Add automated cleanup to ONT transfer script.
+
 ## 20241108.1
 
 Add element instruments to bioinfo_tab

--- a/taca/nanopore/instrument_transfer.py
+++ b/taca/nanopore/instrument_transfer.py
@@ -85,9 +85,7 @@ def delete_archived_runs(args):
     ]
     logging.info(f"Found {len(run_paths)} locally archived runs...")
 
-    preproc_archive_contents = os.listdir(
-        os.path.join(args.dest_dir, "nosync", "archived")
-    )
+    preproc_archive_contents = os.listdir(os.path.join(args.dest_dir, "nosync"))
 
     # Iterate over runs
     for run_path in run_paths:

--- a/taca/nanopore/instrument_transfer.py
+++ b/taca/nanopore/instrument_transfer.py
@@ -88,8 +88,8 @@ def delete_archived_runs(args):
     logging.info(f"Found {len(run_paths)} locally archived runs...")
 
     preproc_archive_contents = set(
-        os.listdir(os.path.join(args.dest_dir, "nosync")),
-        os.listdir(os.path.join(args.dest_dir, "nosync", "archived")),
+        os.listdir(os.path.join(args.dest_dir, "nosync"))
+        + os.listdir(os.path.join(args.dest_dir, "nosync", "archived"))
     )
     # Iterate over runs
     for run_path in run_paths:

--- a/taca/nanopore/instrument_transfer.py
+++ b/taca/nanopore/instrument_transfer.py
@@ -11,6 +11,13 @@ import subprocess
 from datetime import datetime as dt
 from glob import glob
 
+RUN_PATTERN = re.compile(
+    # Run folder name expected as yyyymmdd_HHMM_1A-3H/MN19414_flowCellId_randomHash
+    # Flow cell names starting with "CTC" are configuration test cells and should not be included
+    # As of december 2023, the third column (3A-3H) is excluded, because it will be used by Clinical Genomics
+    r"^\d{8}_\d{4}_(([1-2][A-H])|(MN19414))_(?!CTC)[A-Za-z0-9]+_[A-Za-z0-9]+$"
+)
+
 
 def main(args):
     """Find ONT runs and transfer them to storage.
@@ -24,12 +31,6 @@ def main(args):
 
     logging.info("Starting script...")
 
-    run_pattern = re.compile(
-        # Run folder name expected as yyyymmdd_HHMM_1A-3H/MN19414_flowCellId_randomHash
-        # Flow cell names starting with "CTC" are configuration test cells and should not be included
-        # As of december 2023, the third column (3A-3H) is excluded, because it will be used by Clinical Genomics
-        r"^\d{8}_\d{4}_(([1-2][A-H])|(MN19414))_(?!CTC)[A-Za-z0-9]+_[A-Za-z0-9]+$"
-    )
     rsync_log = os.path.join(args.source_dir, "rsync_log.txt")
 
     logging.info("Parsing instrument position logs...")
@@ -37,12 +38,17 @@ def main(args):
     logging.info("Subsetting QC and MUX metrics...")
     pore_counts = get_pore_counts(position_logs)
 
+    handle_runs(pore_counts, args, rsync_log)
+    delete_archived_runs(args, rsync_log)
+
+
+def handle_runs(pore_counts, args, rsync_log):
     logging.info("Finding runs...")
     # Look for dirs matching run pattern 3 levels deep from source
     run_paths = [
         path
         for path in glob(os.path.join(args.source_dir, "*", "*", "*"), recursive=True)
-        if re.match(run_pattern, os.path.basename(path))
+        if re.match(RUN_PATTERN, os.path.basename(path))
     ]
     logging.info(f"Found {len(run_paths)} runs...")
 
@@ -67,6 +73,52 @@ def main(args):
             sync_to_storage(run_path, rsync_dest, rsync_log)
         else:
             final_sync_to_storage(run_path, rsync_dest, args.archive_dir, rsync_log)
+
+
+def delete_archived_runs(args):
+    logging.info("Finding locally archived runs...")
+    # Look for dirs matching run pattern inside archive dir
+    run_paths = [
+        path
+        for path in glob(os.path.join(args.archive_dir, "*", "*", "*"), recursive=True)
+        if re.match(RUN_PATTERN, os.path.basename(path))
+    ]
+    logging.info(f"Found {len(run_paths)} locally archived runs...")
+
+    preproc_archive_contents = os.listdir(
+        os.path.join(args.dest_dir, "nosync", "archived")
+    )
+
+    # Iterate over runs
+    for run_path in run_paths:
+        logging.info(f"Handling locally archived run {run_path}...")
+        run_name = os.path.basename(run_path)
+
+        if run_name in preproc_archive_contents:
+            logging.info(
+                f"Locally archived run {run_path} was found in the preproc archive. Deleting..."
+            )
+            shutil.rmtree(run_path)
+        else:
+            logging.info(
+                f"Locally archived run {run_path} was not found in the preproc archive. Skipping..."
+            )
+            continue
+
+    # Remove empty dirs
+    sample_dirs = set([os.path.dirname(run_path) for run_path in run_paths])
+    experiment_dirs = set([os.path.dirname(sample_dir) for sample_dir in sample_dirs])
+
+    for sample_dir in sample_dirs:
+        if not os.listdir(sample_dir):
+            logging.info(f"Removing empty dir '{sample_dir}'.")
+            os.rmdir(sample_dir)
+
+    # Remove empty experiment dirs
+    for experiment_dir in experiment_dirs:
+        if not os.listdir(experiment_dir):
+            logging.info(f"Removing empty dir '{experiment_dir}'.")
+            os.rmdir(experiment_dir)
 
 
 def sequencing_finished(run_path: str) -> bool:

--- a/taca/nanopore/instrument_transfer.py
+++ b/taca/nanopore/instrument_transfer.py
@@ -85,8 +85,10 @@ def delete_archived_runs(args):
     ]
     logging.info(f"Found {len(run_paths)} locally archived runs...")
 
-    preproc_archive_contents = os.listdir(os.path.join(args.dest_dir, "nosync"))
-
+    preproc_archive_contents = set(
+        os.listdir(os.path.join(args.dest_dir, "nosync")),
+        os.listdir(os.path.join(args.dest_dir, "nosync", "archived")),
+    )
     # Iterate over runs
     for run_path in run_paths:
         logging.info(f"Handling locally archived run {run_path}...")

--- a/taca/nanopore/instrument_transfer.py
+++ b/taca/nanopore/instrument_transfer.py
@@ -44,11 +44,13 @@ def main(args):
 
 def handle_runs(pore_counts, args, rsync_log):
     logging.info("Finding runs...")
-    # Look for dirs matching run pattern 3 levels deep from source
+    # Look for dirs matching run pattern 3 levels deep from source, excluding certain dirs
+    exclude_dirs = ["nosync", "keep_data", "cg_data"]
     run_paths = [
         path
         for path in glob(os.path.join(args.source_dir, "*", "*", "*"), recursive=True)
         if re.match(RUN_PATTERN, os.path.basename(path))
+        and path.split(os.sep)[-3] not in exclude_dirs
     ]
     logging.info(f"Found {len(run_paths)} runs...")
 

--- a/taca/nanopore/instrument_transfer.py
+++ b/taca/nanopore/instrument_transfer.py
@@ -39,7 +39,7 @@ def main(args):
     pore_counts = get_pore_counts(position_logs)
 
     handle_runs(pore_counts, args, rsync_log)
-    delete_archived_runs(args, rsync_log)
+    delete_archived_runs(args)
 
 
 def handle_runs(pore_counts, args, rsync_log):

--- a/tests/element/test_Element_Runs.py
+++ b/tests/element/test_Element_Runs.py
@@ -552,9 +552,12 @@ class TestRun:
 
     def test_start_demux(self, mock_db, create_dirs):
         tmp: tempfile.TemporaryDirectory = create_dirs
-        with mock.patch("subprocess.Popen") as mock_Popen, mock.patch(
-            "taca.element.Element_Runs.Run.generate_demux_command"
-        ) as mock_command:
+        with (
+            mock.patch("subprocess.Popen") as mock_Popen,
+            mock.patch(
+                "taca.element.Element_Runs.Run.generate_demux_command"
+            ) as mock_command,
+        ):
             mock_command.return_value = "test command"
             run = to_test.Run(create_element_run_dir(create_dirs), get_config(tmp))
             run.start_demux("mock_run_manifest", "mock_demux_dir")

--- a/tests/nanopore/test_instrument_transfer.py
+++ b/tests/nanopore/test_instrument_transfer.py
@@ -32,6 +32,7 @@ def setup_test_fixture():
         args.source_dir,
         args.dest_dir,
         args.dest_dir + "/nosync",
+        args.dest_dir + "/nosync/archived",
         args.dest_dir_qc,
         args.archive_dir,
         args.minknow_logs_dir,

--- a/tests/nanopore/test_instrument_transfer.py
+++ b/tests/nanopore/test_instrument_transfer.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import shutil
 import tempfile
 from unittest.mock import Mock, call, mock_open, patch
 
@@ -75,6 +76,41 @@ def setup_test_fixture():
     yield args, tmp, file_paths
 
     tmp.cleanup()
+
+
+def test_main_delete(setup_test_fixture):
+    """Check so that remotely archived runs runs and empty dirs
+    are deleted from the local archive.
+    """
+
+    # Run fixture
+    args, tmp, file_paths = setup_test_fixture
+
+    # Locally and remotely archived run
+    run_path = f"{args.archive_dir}/experiment/sample/{DUMMY_RUN_NAME}"
+    os.makedirs(run_path)
+    remote_run_path = f"{args.dest_dir}/nosync/{DUMMY_RUN_NAME}"
+    os.makedirs(remote_run_path)
+
+    # Locally but not remotely archived run
+    innocent_run_path = f"{args.archive_dir}/innocent_experiment/innocent_sample/{DUMMY_RUN_NAME.replace('randomhash', 'dontDeleteMe')}"
+    os.makedirs(innocent_run_path)
+
+    with patch("shutil.rmtree", side_effect=shutil.rmtree) as mock_rmtree, patch(
+        "os.rmdir", side_effect=os.rmdir
+    ) as mock_rmdir:
+        # Run code
+        instrument_transfer.main(args)
+
+        # Assert deletions
+        mock_rmtree.assert_has_calls([call(f"{run_path}")])
+        mock_rmdir.assert_has_calls(
+            [
+                call(f"{args.archive_dir}/experiment/sample"),
+                call(f"{args.archive_dir}/experiment"),
+            ]
+        )
+        assert os.path.exists(innocent_run_path)
 
 
 def test_main_ignore_CTC(setup_test_fixture):

--- a/tests/nanopore/test_instrument_transfer.py
+++ b/tests/nanopore/test_instrument_transfer.py
@@ -96,9 +96,10 @@ def test_main_delete(setup_test_fixture):
     innocent_run_path = f"{args.archive_dir}/innocent_experiment/innocent_sample/{DUMMY_RUN_NAME.replace('randomhash', 'dontDeleteMe')}"
     os.makedirs(innocent_run_path)
 
-    with patch("shutil.rmtree", side_effect=shutil.rmtree) as mock_rmtree, patch(
-        "os.rmdir", side_effect=os.rmdir
-    ) as mock_rmdir:
+    with (
+        patch("shutil.rmtree", side_effect=shutil.rmtree) as mock_rmtree,
+        patch("os.rmdir", side_effect=os.rmdir) as mock_rmdir,
+    ):
         # Run code
         instrument_transfer.main(args)
 

--- a/tests/nanopore/test_instrument_transfer.py
+++ b/tests/nanopore/test_instrument_transfer.py
@@ -30,6 +30,7 @@ def setup_test_fixture():
     for dir in [
         args.source_dir,
         args.dest_dir,
+        args.dest_dir + "/nosync",
         args.dest_dir_qc,
         args.archive_dir,
         args.minknow_logs_dir,


### PR DESCRIPTION
Delete runs from the instrument which are found in the `destination/nosync` subdir on the mounted storage.

Initially the idea was to also look in e.g. the `transfer_promethion.tsv` file, but it's located in the home dir of the preproc server itself rather than its mounted storage and so the instrument has no read access from what I can tell.

This PR thus makes the assumption that any run moved to the nosync subdir of the mounted storage has also been sent to miarka.

I considered taking it one step further and looking at `destination/nosync/archived`, but I'm not sure to what extent the archiving is automated, and this subdir is missing for e.g. MinION QC runs.