### PR TITLE
Catch exception in case lane is numeric as is the case with older flowcells

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -2,6 +2,10 @@
 
 ## 20241108.1
 
+Add exception handling for nonnumeric flowcell ids in bioinfo_tab
+
+## 20241108.1
+
 Add element instruments to bioinfo_tab
 
 ## 20241031.1

--- a/taca/utils/bioinfo_tab.py
+++ b/taca/utils/bioinfo_tab.py
@@ -123,7 +123,10 @@ def update_statusdb(run_dir, inst_brand):
                         # Special if case to handle lanes written as int, can be safely removed when old lanes
                         # is no longer stored as int
                         try:
-                            if len(view[[project, run_id, int(lane), sample]].rows) >= 1:
+                            if (
+                                len(view[[project, run_id, int(lane), sample]].rows)
+                                >= 1
+                            ):
                                 lane = int(lane)
                         except ValueError:
                             pass

--- a/taca/utils/bioinfo_tab.py
+++ b/taca/utils/bioinfo_tab.py
@@ -122,8 +122,11 @@ def update_statusdb(run_dir, inst_brand):
                         # If entry exists, append to existing
                         # Special if case to handle lanes written as int, can be safely removed when old lanes
                         # is no longer stored as int
-                        if len(view[[project, run_id, int(lane), sample]].rows) >= 1:
-                            lane = int(lane)
+                        try:
+                            if len(view[[project, run_id, int(lane), sample]].rows) >= 1:
+                                lane = int(lane)
+                        except ValueError:
+                            pass
                         if len(view[[project, run_id, lane, sample]].rows) >= 1:
                             remote_id = view[[project, run_id, lane, sample]].rows[0].id
                             lane = str(lane)


### PR DESCRIPTION
Not sure how old these flowcells are, but they probably exist in the database.
Aviti FCs have a default value of '1+2' for lane.