### PR TITLE
ToulligQC fixes

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,9 @@
 # TACA Version Log
 
+## 20241210.1
+
+Tweaks and bugfixes for ToulligQC.
+
 ## 20241204.2
 
 Add automated QC reports with ToulligQC for ONT.

--- a/taca/nanopore/ONT_run_classes.py
+++ b/taca/nanopore/ONT_run_classes.py
@@ -385,10 +385,13 @@ class ONT_run:
             samplesheet = ss_glob[0]
 
         # Run has barcode subdirs
-        if len(glob.glob(f"{self.run_abspath}/fastq_pass/barcode*")) > 0:
+        barcode_dirs_glob = glob.glob(f"{self.run_abspath}/{raw_data_dir}/barcode*")
+        if len(barcode_dirs_glob) > 0:
             barcode_dirs = True
+            raw_data_path = barcode_dirs_glob[0]
         else:
             barcode_dirs = False
+            raw_data_path = f"{self.run_abspath}/{raw_data_dir}"
 
         # Determine barcodes
         if samplesheet:
@@ -407,7 +410,7 @@ class ONT_run:
 
         command_args = {
             "--sequencing-summary-source": summary,
-            f"--{raw_data_format}-source": f"{self.run_abspath}/{raw_data_dir}",
+            f"--{raw_data_format}-source": raw_data_path,
             "--output-directory": self.run_abspath,
             "--report-name": "toulligqc_report",
         }
@@ -443,7 +446,7 @@ class ONT_run:
         report_src_path = self.get_file("/toulligqc_report/report.html")
         report_dest_path = os.path.join(
             self.toulligqc_reports_dir,
-            f"ToulligQC_{self.run_name}.html",
+            f"report_{self.run_name}.html",
         )
         transfer_object = RsyncAgent(
             src_path=report_src_path,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,8 @@ def create_dirs():
         │   └── promethion
         ├── ngi-internal
         │   ├── minknow_reports
-        │   └── toulligqc_reports
+        │   └── other_reports
+        │       └── toulligqc_reports
         ├── ngi-nas-ns
         │   ├── Aviti_data
         │   ├── NextSeq_data
@@ -95,7 +96,7 @@ def create_dirs():
 
     # GenStat
     os.makedirs(f"{tmp.name}/ngi-internal/minknow_reports")
-    os.makedirs(f"{tmp.name}/ngi-internal/toulligqc_reports")
+    os.makedirs(f"{tmp.name}/ngi-internal/other_reports/toulligqc_reports")
 
     # Misc. ONT dirs/files
     os.makedirs(f"{tmp.name}/log")

--- a/tests/nanopore/test_ONT_run_classes.py
+++ b/tests/nanopore/test_ONT_run_classes.py
@@ -50,7 +50,7 @@ nanopore_analysis:
                 anglerfish_samplesheets_dir: {tmp.name}/ngi-nas-ns/samplesheets/anglerfish
                 anglerfish_path: mock
     minknow_reports_dir: {tmp.name}/ngi-internal/minknow_reports/
-    toulligqc_reports_dir: {tmp.name}/ngi-internal/toulligqc_reports/
+    toulligqc_reports_dir: {tmp.name}/ngi-internal/other_reports/toulligqc_reports/
     toulligqc_executable: toulligqc
     rsync_options:
         '-Lav': None


### PR DESCRIPTION
- Accommodate barcoded runs, whose raw data will be binned by barcode
- Use expected rename of report when copying it to ngi-internal
- Update test configuration to reflect reality