### PR TITLE
Fix missing samplesheet issue

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,9 @@
 # TACA Version Log
 
+## 20241211.1
+
+Email user instead of craching if unable to create Illumina runobject
+
 ## 20241210.4
 
 Change server_status nas to update statusdb by default

--- a/taca/__init__.py
+++ b/taca/__init__.py
@@ -1,3 +1,3 @@
 """Main TACA module"""
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -522,7 +522,7 @@ def run_preprocessing(run, software):
                 try:
                     runObj = get_runObj(_run, software)
                 except:
-                    # This might throw and exception e.g. if samplesheet is missing.
+                    # This might throw an exception e.g. if the samplesheet is missing.
                     # It is better to continue processing other runs
                     logger.warning(
                         f"There was an error setting up a run object for {_run}"

--- a/taca/illumina/Runs.py
+++ b/taca/illumina/Runs.py
@@ -221,10 +221,11 @@ class Run:
         if os.path.exists(ssname):
             return ssname
         else:
+            logger.warning(
+                f"Not able to find samplesheet {self.flowcell_id}.csv in {self.CONFIG["samplesheets_dir"]}"
+            )
             raise RuntimeError(
-                "not able to find samplesheet {}.csv in {}".format(
-                    self.flowcell_id, self.CONFIG["samplesheets_dir"]
-                )
+                f"Not able to find samplesheet {self.flowcell_id}.csv in {self.CONFIG["samplesheets_dir"]}"
             )
 
     def _is_demultiplexing_done(self):

--- a/taca/illumina/Runs.py
+++ b/taca/illumina/Runs.py
@@ -222,10 +222,10 @@ class Run:
             return ssname
         else:
             logger.warning(
-                f"Not able to find samplesheet {self.flowcell_id}.csv in {self.CONFIG["samplesheets_dir"]}"
+                f"Not able to find samplesheet {self.flowcell_id}.csv in {self.CONFIG['samplesheets_dir']}"
             )
             raise RuntimeError(
-                f"Not able to find samplesheet {self.flowcell_id}.csv in {self.CONFIG["samplesheets_dir"]}"
+                f"Not able to find samplesheet {self.flowcell_id}.csv in {self.CONFIG['samplesheets_dir']}"
             )
 
     def _is_demultiplexing_done(self):


### PR DESCRIPTION
If the samplesheet from LIMS is missing, TACA throws an exception when trying to set up a runobject for Illumina runs. Instead, log a warning and email the user.