### PR TITLE
Make it possible to "hide" old runs from TACA in transfer log

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,9 @@
 # TACA Version Log
 
+## 20250326.1
+
+Make it possible to "hide" old aviti runs from TACA in transfer log
+
 ## 20250324.1
 
 Typo fix

--- a/taca/__init__.py
+++ b/taca/__init__.py
@@ -1,3 +1,3 @@
 """Main TACA module"""
 
-__version__ = "1.5.5"
+__version__ = "1.5.6"

--- a/taca/element/Element_Runs.py
+++ b/taca/element/Element_Runs.py
@@ -765,7 +765,7 @@ class Run:
     def in_transfer_log(self):
         with open(self.transfer_file) as transfer_file:
             for row in transfer_file.readlines():
-                if self.NGI_run_id in row:
+                if row.startswith(self.NGI_run_id):
                     return True
         return False
 


### PR DESCRIPTION
So that we can keep the original transfer in the aviti transfer log.