### PR TITLE
Fail organisation of ONT data if tar fails

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,9 @@
 # TACA Version Log
 
+## 20250527.1
+
+Bugfix: Fail organisation of ONT data if tar fails
+
 ## 20250404.1
 
 Add URL to Element FCs in email notifications

--- a/taca/__init__.py
+++ b/taca/__init__.py
@@ -1,3 +1,3 @@
 """Main TACA module"""
 
-__version__ = "1.5.10"
+__version__ = "1.5.11"


### PR DESCRIPTION
For ONT organisation, this should make TACA fail if the `tar` fails, for instance if the run folder is moved during tar-ing. 