### PR TITLE
Update TACA to handle AVITI24 Teton runs

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,9 @@
 # TACA Version Log
 
+## 20250910.1
+
+Update Element analysis to handle AVITI24 Teton runs
+
 ## 20250909.1
 
 Update Element analysis to handle NoIndex cases

--- a/taca/__init__.py
+++ b/taca/__init__.py
@@ -1,3 +1,3 @@
 """Main TACA module"""
 
-__version__ = "1.6.4"
+__version__ = "1.6.5"

--- a/taca/analysis/analysis_element.py
+++ b/taca/analysis/analysis_element.py
@@ -196,6 +196,7 @@ def run_preprocessing(given_run):
             for run in runs:
                 if "FlowcellPressureCheck" in run:
                     # Skip the pressure check runs (Teton runs)
+                    logger.info(f"Skipping {run}")  # TODO: should these be synced?
                     continue
                 if run in teton_runs:
                     runObj = Teton_Run(run, CONFIG)

--- a/taca/analysis/analysis_element.py
+++ b/taca/analysis/analysis_element.py
@@ -148,17 +148,13 @@ def run_preprocessing(given_run):
             if run.status_changed():
                 run.update_statusdb()
             run.move_to_nosync()
-            run.status = "processed"
             email_subject = f"{run} has been transferred to the analysis cluster"
             email_message = (
                 f"Rsync of data for run {run} to the analysis cluster has finished!\n"
                 f"The run is available at https://genomics-status.scilifelab.se/flowcells_element/{run}"
             )
             send_mail(email_subject, email_message, CONFIG["mail"]["recipients"])
-
-            if run.status_changed():
-                run.update_statusdb()
-            return
+            
         elif transfer_status == "rsync failed":
             run.status = "transfer failed"
             logger.warning(

--- a/taca/analysis/analysis_element.py
+++ b/taca/analysis/analysis_element.py
@@ -56,7 +56,9 @@ def run_preprocessing(given_run):
 
         #### Demultiplexing status ####
         if run.run_type == "Cytoprofiling":
-            logger.info(f"Skipping demultiplexing for {run} as it is a Cytoprofiling run")
+            logger.info(
+                f"Skipping demultiplexing for {run} as it is a Cytoprofiling run"
+            )
             pass
         else:
             demultiplexing_status = run.get_demultiplexing_status()
@@ -154,7 +156,7 @@ def run_preprocessing(given_run):
                 f"The run is available at https://genomics-status.scilifelab.se/flowcells_element/{run}"
             )
             send_mail(email_subject, email_message, CONFIG["mail"]["recipients"])
-            
+
         elif transfer_status == "rsync failed":
             run.status = "transfer failed"
             logger.warning(

--- a/taca/analysis/analysis_element.py
+++ b/taca/analysis/analysis_element.py
@@ -59,7 +59,6 @@ def run_preprocessing(given_run):
             logger.info(
                 f"Skipping demultiplexing for {run} as it is a Cytoprofiling run"
             )
-            pass
         else:
             demultiplexing_status = run.get_demultiplexing_status()
             if demultiplexing_status == "not started":

--- a/taca/element/Aviti_Runs.py
+++ b/taca/element/Aviti_Runs.py
@@ -10,10 +10,3 @@ class Aviti_Run(Run):
         self.sequencer_type = "Aviti"
         self.demux_dir = "Demultiplexing"
         super().__init__(run_dir, configuration)
-
-    def check_side_letter(self):
-        if self.side_letter != self.run_dir.split("_")[-1][0]:
-            logger.warning(
-                f"Side specified by sequencing operator does not match side from instrument for {self}. Aborting."
-            )
-            raise AssertionError(f"Inconcistencies in side assignments for {self}")

--- a/taca/element/Aviti_Runs.py
+++ b/taca/element/Aviti_Runs.py
@@ -1,4 +1,8 @@
+import logging
+
 from taca.element.Element_Runs import Run
+
+logger = logging.getLogger(__name__)
 
 
 class Aviti_Run(Run):
@@ -6,3 +10,25 @@ class Aviti_Run(Run):
         self.sequencer_type = "Aviti"
         self.demux_dir = "Demultiplexing"
         super().__init__(run_dir, configuration)
+
+    def check_side_letter(self):
+        if self.side_letter != self.run_dir.split("_")[-1][0]:
+            logger.warning(
+                f"Side specified by sequencing operator does not match side from instrument for {self}. Aborting."
+            )
+            raise AssertionError(f"Inconcistencies in side assignments for {self}")
+
+
+class Teton_Run(Run):
+    def __init__(self, run_dir, configuration):
+        self.sequencer_type = "Aviti"
+        super().__init__(run_dir, configuration)
+
+    def check_side_letter(self):
+        if (
+            self.side_letter != self.run_dir.split("_")[-2][0]
+        ):  # Teton runs have _User or _Ctrl after the FC ID
+            logger.warning(
+                f"Side specified by sequencing operator does not match side from instrument for {self}. Aborting."
+            )
+            raise AssertionError(f"Inconcistencies in side assignments for {self}")

--- a/taca/element/Aviti_Runs.py
+++ b/taca/element/Aviti_Runs.py
@@ -17,18 +17,3 @@ class Aviti_Run(Run):
                 f"Side specified by sequencing operator does not match side from instrument for {self}. Aborting."
             )
             raise AssertionError(f"Inconcistencies in side assignments for {self}")
-
-
-class Teton_Run(Run):
-    def __init__(self, run_dir, configuration):
-        self.sequencer_type = "Aviti"
-        super().__init__(run_dir, configuration)
-
-    def check_side_letter(self):
-        if (
-            self.side_letter != self.run_dir.split("_")[-2][0]
-        ):  # Teton runs have _User or _Ctrl after the FC ID
-            logger.warning(
-                f"Side specified by sequencing operator does not match side from instrument for {self}. Aborting."
-            )
-            raise AssertionError(f"Inconcistencies in side assignments for {self}")

--- a/taca/element/Element_Runs.py
+++ b/taca/element/Element_Runs.py
@@ -253,6 +253,13 @@ class Run:
         else:
             raise RuntimeError(f"Run parameters not parsed for run {self.run_dir}")
 
+    def check_side_letter(self):
+        if self.side_letter != self.run_dir.split("_")[-1][0]:
+            logger.warning(
+                f"Side specified by sequencing operator does not match side from instrument for {self}. Aborting."
+            )
+            raise AssertionError(f"Inconcistencies in side assignments for {self}")
+
     def parse_run_parameters(self) -> None:
         """Parse run-information from the RunParameters.json file"""
         try:

--- a/taca/element/Element_Runs.py
+++ b/taca/element/Element_Runs.py
@@ -276,8 +276,10 @@ class Run:
         self.run_type = run_parameters.get(
             "RunType"
         )  # Sequencing, Cytoprofiling, wash or prime I believe?
-        self.flowcell_id = run_parameters.get("FlowcellID") #FIXME: teton runs don't have FlowcellID in the RunParameters.json
-        self.cycles = run_parameters.get("Cycles", {"R1": 0, "R2": 0, "I1": 0, "I2": 0}) #FIXME: teton runs don't have Cycles in the RunParameters.json
+        self.flowcell_id = run_parameters.get(
+            "FlowcellID"
+        )  # FIXME: teton runs don't have FlowcellID in the RunParameters.json
+        self.cycles = run_parameters.get("Cycles", {"R1": 0, "R2": 0, "I1": 0, "I2": 0})
         self.instrument_name = run_parameters.get("InstrumentName")
         self.date = run_parameters.get("Date")[0:10].replace("-", "")
         self.year = self.date[0:4]
@@ -1327,7 +1329,7 @@ class Run:
             if os.path.exists(f):
                 shutil.copy(f, dest)
             else:
-                logger.warning(f"File {f} missing for run {self.run}")
+                logger.warning(f"File {f} missing for run {self.NGI_run_id}")
 
     def make_transfer_indicator(self):
         transfer_indicator = os.path.join(self.run_dir, ".rsync_ongoing")

--- a/taca/element/Element_Runs.py
+++ b/taca/element/Element_Runs.py
@@ -276,9 +276,10 @@ class Run:
         self.run_type = run_parameters.get(
             "RunType"
         )  # Sequencing, Cytoprofiling, wash or prime
-        self.flowcell_id = (
-            run_parameters.get("Consumables").get("Flowcell").get("SerialNumber")
-        )  # Teton runs don't have FlowcellID in the RunParameters.json, so we need to get it from Consumables
+        if self.run_type == "Cytoprofiling":
+            self.flowcell_id = self.run_name  # Teton runs don't have FlowcellID in the RunParameters.json, the PID is used instead
+        else:
+            self.flowcell_id = run_parameters.get("FlowcellID")
         self.cycles = run_parameters.get("Cycles", {"R1": 0, "R2": 0, "I1": 0, "I2": 0})
         self.instrument_name = run_parameters.get("InstrumentName")
         self.date = run_parameters.get("Date")[0:10].replace("-", "")

--- a/taca/element/Element_Runs.py
+++ b/taca/element/Element_Runs.py
@@ -272,16 +272,12 @@ class Run:
         )  # Unique hash that we don't really use
         self.side = run_parameters.get("Side")  # SideA or SideB
         self.side_letter = self.side[-1]  # A or B
-        if self.side_letter != self.run_dir.split("_")[-1][0]:
-            logger.warning(
-                f"Side specified by sequencing operator does not match side from instrument for {self}. Aborting."
-            )
-            raise AssertionError(f"Inconcistencies in side assignments for {self}")
+        self.check_side_letter()
         self.run_type = run_parameters.get(
             "RunType"
-        )  # Sequencing, wash or prime I believe?
-        self.flowcell_id = run_parameters.get("FlowcellID")
-        self.cycles = run_parameters.get("Cycles", {"R1": 0, "R2": 0, "I1": 0, "I2": 0})
+        )  # Sequencing, Cytoprofiling, wash or prime I believe?
+        self.flowcell_id = run_parameters.get("FlowcellID") #FIXME: teton runs don't have FlowcellID in the RunParameters.json
+        self.cycles = run_parameters.get("Cycles", {"R1": 0, "R2": 0, "I1": 0, "I2": 0}) #FIXME: teton runs don't have Cycles in the RunParameters.json
         self.instrument_name = run_parameters.get("InstrumentName")
         self.date = run_parameters.get("Date")[0:10].replace("-", "")
         self.year = self.date[0:4]


### PR DESCRIPTION
TACA will now:
* Skip any `FlowcellPressureCheck` dirs
* For runs where `RunType` is `Cytoprofiling` in `RunParameters.json`, skip demux and instead directly rsync the runs to Miarka, as well as update the metadata in StatusDB.