### PR TITLE
Bugfix: catch CalledProcessError

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,9 @@
 # TACA Version Log
 
+## 20260827.1
+
+Bugfix: catch failed tar and md5sum subprocesses
+
 ## 20260626.1
 
 ONT transfer script fix: don't sync runs that didn't start

--- a/taca/__init__.py
+++ b/taca/__init__.py
@@ -1,3 +1,3 @@
 """Main TACA module"""
 
-__version__ = "1.6.22"
+__version__ = "1.6.23"

--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -268,7 +268,7 @@ def transfer_runfolder(run_dir, pid, exclude_lane):
         if exclude_lane != "":
             exclude_options_for_tar += dir_for_excluding_lane
 
-        subprocess.call(
+        subprocess.check_call(
             ["tar"]
             + exclude_options_for_tar
             + [
@@ -289,7 +289,7 @@ def transfer_runfolder(run_dir, pid, exclude_lane):
     try:
         f = open(md5file, "w")
         os.chdir(run_dir_path)
-        subprocess.call(["md5sum", os.path.basename(archive)], stdout=f)
+        subprocess.check_call(["md5sum", os.path.basename(archive)], stdout=f)
         f.close()
     except subprocess.CalledProcessError as e:
         logger.error("Error creating md5 file")


### PR DESCRIPTION
subprocess.call() never raises subprocess.CalledProcessError. Use subprocess.check_call() instead.